### PR TITLE
Add 2 test cases for FFmpeg

### DIFF
--- a/test_cases/ffmpeg/av_free/reddit/rpan_studio_av_free.c
+++ b/test_cases/ffmpeg/av_free/reddit/rpan_studio_av_free.c
@@ -1,0 +1,27 @@
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+
+int Test_ff_codec_desc_free() {
+    // Initialize FFmpeg libraries
+    av_register_all();
+    avformat_network_init();
+
+    // Begin function parameters
+    const AVCodecDescriptor *codec_desc = avcodec_descriptor_next(NULL);
+    // End function parameters
+    const AVCodecDescriptor *current_desc = codec_desc;
+    while (current_desc != NULL) {
+        const AVCodecDescriptor *next_desc = avcodec_descriptor_next(current_desc);
+        // No need to free codec descriptors, they are statically allocated
+        current_desc = next_desc;
+    }
+
+    // Clean up FFmpeg libraries
+    avformat_network_deinit();
+
+    return 0;
+}
+
+int main() {
+    return Test_ff_codec_desc_free();
+}

--- a/test_cases/ffmpeg/av_free/reddit/rpan_studio_av_free.c
+++ b/test_cases/ffmpeg/av_free/reddit/rpan_studio_av_free.c
@@ -1,5 +1,5 @@
-#include <libavcodec/avcodec.h>
-#include <libavformat/avformat.h>
+#include "libavcodec/avcodec.h"
+#include "libavformat/avformat.h"
 
 int Test_ff_codec_desc_free() {
     // Initialize FFmpeg libraries

--- a/test_cases/ffmpeg/av_freep/reddit/rpan_studio_av_freep.c
+++ b/test_cases/ffmpeg/av_freep/reddit/rpan_studio_av_freep.c
@@ -1,7 +1,7 @@
-#include <libavutil/frame.h>
-#include <libavutil/mem.h>
-#include <libavcodec/avcodec.h>
-#include <libavformat/avformat.h>
+#include "libavutil/frame.h"
+#include "libavutil/mem.h"
+#include "libavcodec/avcodec.h"
+#include "libavformat/avformat.h"
 
 struct enc_encoder {
     uint8_t *samples[1];

--- a/test_cases/ffmpeg/av_freep/reddit/rpan_studio_av_freep.c
+++ b/test_cases/ffmpeg/av_freep/reddit/rpan_studio_av_freep.c
@@ -1,0 +1,34 @@
+#include <libavutil/frame.h>
+#include <libavutil/mem.h>
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+
+struct enc_encoder {
+    uint8_t *samples[1];
+    AVFrame *aframe;
+};
+
+int Test_enc_destroy() {
+    // Initialize function parameters
+    struct enc_encoder enc;
+    enc.samples[0] = (uint8_t *)av_malloc(100); // Allocate memory for the sample
+    enc.aframe = av_frame_alloc(); // Allocate memory for the audio frame
+
+    // Free the first sample if it exists
+    uint8_t *first_sample = enc.samples[0];
+    if (first_sample) {
+        av_freep(&enc.samples[0]);
+    }
+
+    // Free the audio frame if it exists
+    AVFrame *audio_frame = enc.aframe;
+    if (audio_frame) {
+        av_frame_free(&enc.aframe);
+    }
+
+    return 0;
+}
+
+int main() {
+    return Test_enc_destroy();
+}


### PR DESCRIPTION
## Multiple Test Cases Addition

**Library:** FFmpeg
**Total Test Cases:** 2
**Target APIs:** av_free, av_freep

### Coverage Summary

| Test Case | Target API | Coverage Before | Coverage After | Improvement | Covered Lines Change |
|-----------|------------|-----------------|----------------|-------------|---------------------|
| reddit/rpan-studio_av_free | av_free | 0.0% | 0.0% | +0.0% | +0 |
| reddit/rpan-studio_av_freep | av_freep | 0.0% | 0.0% | +0.0% | +0 |


### Test Case Details

This PR adds 2 new test cases generated by the CodeSA TestGeneration system to improve test coverage for multiple APIs in the FFmpeg library.

