### PR TITLE
Add test case for av_find_best_stream - +0.0% coverage (+11 lines)

### DIFF
--- a/test_cases/av_find_best_stream/reddit/rpan_studio_av_find_best_stream.c
+++ b/test_cases/av_find_best_stream/reddit/rpan_studio_av_find_best_stream.c
@@ -1,0 +1,87 @@
+#include <libavformat/avformat.h>
+#include <libavcodec/avcodec.h>
+#include <libavutil/dict.h>
+#include <libavutil/frame.h>
+#include <libavutil/log.h>
+#include <libavdevice/avdevice.h>
+
+struct mp_decode {
+    AVCodec *codec;
+    AVFrame *sw_frame;
+    AVFrame *hw_frame;
+    AVStream *stream;
+};
+
+typedef struct {
+    AVFormatContext *fmt;
+    struct mp_decode v;
+    struct mp_decode a;
+} mp_media_t;
+
+int Test_mp_decode_init() {
+    // Begin function parameters
+    enum AVMediaType type = AVMEDIA_TYPE_VIDEO; // Example initialization
+    mp_media_t *m = av_mallocz(sizeof(mp_media_t)); // Example allocation
+    // End function parameters
+
+    // Register all devices and network components
+    avdevice_register_all();
+    avformat_network_init();
+
+    // Open input file and retrieve format context
+    if (avformat_open_input(&m->fmt, "input.mp4", NULL, NULL) < 0) {
+        return -1; // Error opening file
+    }
+
+    // Retrieve stream information
+    if (avformat_find_stream_info(m->fmt, NULL) < 0) {
+        return -1; // Error finding stream info
+    }
+
+    // Determine the appropriate decode structure based on media type
+    struct mp_decode *d = (type == AVMEDIA_TYPE_VIDEO) ? &m->v : &m->a;
+    AVStream *stream;
+
+    // Initialize the decode structure
+    memset(d, 0, sizeof(*d));
+
+    // Find the best stream for the given media type
+    int ret = av_find_best_stream(m->fmt, type, -1, -1, NULL, 0);
+    if (ret < 0) {
+        return -1; // Error finding best stream
+    }
+    stream = d->stream = m->fmt->streams[ret];
+
+    // Get the codec ID from the stream
+    enum AVCodecID id = stream->codecpar->codec_id;
+
+    // Check for alpha mode in stream metadata
+    AVDictionaryEntry *tag =
+        av_dict_get(stream->metadata, "alpha_mode", NULL, AV_DICT_IGNORE_SUFFIX);
+
+    // Determine the codec based on codec ID
+    const char *codec_name = (id == AV_CODEC_ID_VP8) ? "libvpx" : "libvpx-vp9";
+    d->codec = avcodec_find_decoder_by_name(codec_name);
+
+    // Fallback to finding decoder by codec ID
+    if (!d->codec) {
+        d->codec = avcodec_find_decoder(id);
+    }
+
+    // Allocate frames for software and hardware decoding
+    d->sw_frame = av_frame_alloc();
+    d->hw_frame = av_frame_alloc();
+
+    // Log media type for debugging purposes
+    av_log(NULL, AV_LOG_INFO, "Media type: %s\n", av_get_media_type_string(type));
+
+    // Clean up
+    avformat_close_input(&m->fmt);
+    av_free(m);
+
+    return 0;
+}
+
+int main() {
+    return Test_mp_decode_init();
+}


### PR DESCRIPTION
## Test Case Addition

**Target API:** av_find_best_stream
**Library:** FFmpeg
**Test Case:** reddit/rpan-studio_av_find_best_stream

### Coverage Impact

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| **Coverage** | 19.5% | 19.5% | +0.0% |
| **Covered Lines** | 146,396 | 146,407 | +11 |
| **Total Lines** | 752,325 | 752,325 | +0 |

### Test Case Details

This PR adds a new test case generated by the CodeSA TestGeneration system to improve test coverage for the `av_find_best_stream` API in the FFmpeg library.

**Generated by:** CodeSA TestGeneration System
**Test Case ID:** reddit/rpan-studio_av_find_best_stream

### Coverage Improvement
This test case improves coverage by **0.0%** (+11 additional covered lines).

**Test Case Size:** 2,490 characters