### PR TITLE
Add test case for avcodec_free_context - +0.0% coverage (+1 lines)

### DIFF
--- a/test_cases/avcodec_free_context/reddit/rpan_studio_avcodec_free_context.c
+++ b/test_cases/avcodec_free_context/reddit/rpan_studio_avcodec_free_context.c
@@ -1,0 +1,82 @@
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libswscale/swscale.h>
+#include <libavutil/avutil.h>
+#include <libavutil/frame.h>
+#include <libavutil/buffer.h>
+
+struct mp_decode {
+    AVCodecContext *decoder;
+    AVFrame *hw_frame;
+    AVFrame *sw_frame;
+    AVBufferRef *hw_ctx;
+};
+
+void mp_decode_clear_packets(struct mp_decode *d) {
+    // Implementation to clear packets
+}
+
+int Test_mp_decode_free() {
+    struct mp_decode *d = (struct mp_decode *)av_mallocz(sizeof(struct mp_decode));
+    if (!d) return -1;
+
+    // Initialize decoder context
+    d->decoder = avcodec_alloc_context3(NULL);
+    if (!d->decoder) {
+        av_free(d);
+        return -1;
+    }
+
+    // Initialize frames
+    d->hw_frame = av_frame_alloc();
+    d->sw_frame = av_frame_alloc();
+    if (!d->hw_frame || !d->sw_frame) {
+        avcodec_free_context(&d->decoder);
+        av_free(d);
+        return -1;
+    }
+
+    // Initialize hardware context
+    d->hw_ctx = av_buffer_alloc(1024); // Example size
+    if (!d->hw_ctx) {
+        av_frame_free(&d->hw_frame);
+        av_frame_free(&d->sw_frame);
+        avcodec_free_context(&d->decoder);
+        av_free(d);
+        return -1;
+    }
+
+    // Clear packets
+    mp_decode_clear_packets(d);
+
+    // Free hardware frame if it exists
+    if (d->hw_frame != NULL) {
+        av_frame_unref(d->hw_frame);
+        av_frame_free(&d->hw_frame);
+    }
+
+    // Free decoder context if it exists
+    if (d->decoder != NULL) {
+        avcodec_free_context(&d->decoder);
+    }
+
+    // Free software frame if it exists
+    if (d->sw_frame != NULL) {
+        av_frame_unref(d->sw_frame);
+        av_frame_free(&d->sw_frame);
+    }
+
+    // Unreference hardware context if it exists
+    if (d->hw_ctx != NULL) {
+        av_buffer_unref(&d->hw_ctx);
+    }
+
+    // Free the mp_decode structure
+    av_free(d);
+
+    return 0;
+}
+
+int main() {
+    return Test_mp_decode_free();
+}


### PR DESCRIPTION
## Test Case Addition

**Target API:** avcodec_free_context
**Library:** FFmpeg
**Test Case:** reddit/rpan-studio_avcodec_free_context

### Coverage Impact

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| **Coverage** | 19.5% | 19.5% | +0.0% |
| **Covered Lines** | 146,396 | 146,397 | +1 |
| **Total Lines** | 752,325 | 752,325 | +0 |

### Test Case Details

This PR adds a new test case generated by the CodeSA TestGeneration system to improve test coverage for the `avcodec_free_context` API in the FFmpeg library.

**Generated by:** CodeSA TestGeneration System
**Test Case ID:** reddit/rpan-studio_avcodec_free_context

### Coverage Improvement
This test case improves coverage by **0.0%** (+1 additional covered lines).

**Test Case Size:** 1,912 characters