### PR TITLE
Add test case for av_frame_unref - +0.0% coverage (+1 lines)

### DIFF
--- a/test_cases/av_frame_unref/reddit/rpan_studio_av_frame_unref.c
+++ b/test_cases/av_frame_unref/reddit/rpan_studio_av_frame_unref.c
@@ -1,0 +1,64 @@
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libswscale/swscale.h>
+#include <libavutil/frame.h>
+#include <libavutil/buffer.h>
+
+struct mp_decode {
+    AVFrame *hw_frame;
+    AVFrame *sw_frame;
+    AVCodecContext *decoder;
+    AVBufferRef *hw_ctx;
+};
+
+void mp_decode_clear_packets(struct mp_decode *d) {
+    // Implementation for clearing packets
+}
+
+int Test_mp_decode_free() {
+    struct mp_decode *d = (struct mp_decode *)av_mallocz(sizeof(struct mp_decode));
+    if (!d) {
+        return -1; // Memory allocation failed
+    }
+
+    // Initialize frames and decoder context for testing
+    d->hw_frame = av_frame_alloc();
+    d->sw_frame = av_frame_alloc();
+    d->decoder = avcodec_alloc_context3(NULL);
+    d->hw_ctx = av_buffer_alloc(100); // Example size
+
+    // Clear packets
+    mp_decode_clear_packets(d);
+
+    // Free hardware frame if it exists
+    if (d->hw_frame != NULL) {
+        av_frame_unref(d->hw_frame);
+        av_frame_free(&d->hw_frame);
+    }
+
+    // Free decoder context if it exists
+    if (d->decoder != NULL) {
+        avcodec_free_context(&d->decoder);
+    }
+
+    // Free software frame if it exists
+    if (d->sw_frame != NULL) {
+        av_frame_unref(d->sw_frame);
+        av_frame_free(&d->sw_frame);
+    }
+
+    // Unreference hardware context if it exists
+    if (d->hw_ctx != NULL) {
+        av_buffer_unref(&d->hw_ctx);
+    }
+
+    av_free(d);
+    return 0;
+}
+
+int main() {
+    avformat_network_init();
+    int result = Test_mp_decode_free();
+    avformat_network_deinit();
+    return result;
+}


### PR DESCRIPTION
## Test Case Addition

**Target API:** av_frame_unref
**Library:** FFmpeg
**Test Case:** reddit/rpan-studio_av_frame_unref

### Coverage Impact

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| **Coverage** | 19.5% | 19.5% | +0.0% |
| **Covered Lines** | 146,396 | 146,397 | +1 |
| **Total Lines** | 752,325 | 752,325 | +0 |

### Test Case Details

This PR adds a new test case generated by the CodeSA TestGeneration system to improve test coverage for the `av_frame_unref` API in the FFmpeg library.

**Generated by:** CodeSA TestGeneration System
**Test Case ID:** reddit/rpan-studio_av_frame_unref

### Coverage Improvement
This test case improves coverage by **0.0%** (+1 additional covered lines).

**Test Case Size:** 1,558 characters