### PR TITLE
Add test case for sws_freeContext - +0.0% coverage (+11 lines)

### DIFF
--- a/test_cases/sws_freecontext/reddit/rpan_studio_sws_freecontext.c
+++ b/test_cases/sws_freecontext/reddit/rpan_studio_sws_freecontext.c
@@ -1,0 +1,41 @@
+#include <libavcodec/avcodec.h>
+#include <libavdevice/avdevice.h>
+#include <libavformat/avformat.h>
+#include <libswscale/swscale.h>
+
+struct ffmpeg_source {
+    struct SwsContext *sws_ctx;
+};
+
+int Test_ffmpeg_source_destroy() {
+    // Initialize function parameters
+    struct ffmpeg_source s;
+    s.sws_ctx = NULL;
+
+    // Initialize FFmpeg libraries
+    avdevice_register_all();
+    avformat_network_init();
+
+    // Create a SwsContext for testing purposes
+    s.sws_ctx = sws_getContext(
+        640, 480, AV_PIX_FMT_YUV420P, // Source width, height, and format
+        640, 480, AV_PIX_FMT_RGB24,   // Destination width, height, and format
+        SWS_BILINEAR,                 // Scaling algorithm
+        NULL, NULL, NULL              // Optional parameters
+    );
+
+    // Check if sws_ctx is not null and free the context if it exists
+    if (s.sws_ctx != NULL) {
+        sws_freeContext(s.sws_ctx);
+        s.sws_ctx = NULL; // Set to NULL after freeing
+    }
+
+    // Clean up FFmpeg libraries
+    avformat_network_deinit();
+
+    return 0;
+}
+
+int main() {
+    return Test_ffmpeg_source_destroy();
+}


### PR DESCRIPTION
## Test Case Addition

**Target API:** sws_freeContext
**Library:** FFmpeg
**Test Case:** reddit/rpan-studio_sws_freecontext

### Coverage Impact

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| **Coverage** | 19.5% | 19.5% | +0.0% |
| **Covered Lines** | 146,396 | 146,407 | +11 |
| **Total Lines** | 752,325 | 752,325 | +0 |

### Test Case Details

This PR adds a new test case generated by the CodeSA TestGeneration system to improve test coverage for the `sws_freeContext` API in the FFmpeg library.

**Generated by:** CodeSA TestGeneration System
**Test Case ID:** reddit/rpan-studio_sws_freecontext

### Coverage Improvement
This test case improves coverage by **0.0%** (+11 additional covered lines).

**Test Case Size:** 1,106 characters